### PR TITLE
Fix default value for position option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Options
 | -------------------- | --------- | --------------     | ----------- |
 | `nanometersPerPixel` | `Number`  | `1000`             | The ratio between pixels at known zoom and nanometers. |
 | `ratioAtZoom`        | `Number`  | `map.getMaxZoom()` | The zoom level used for translating pixels to distances. |
-| `position`           | `String`  | `'bottomleft'`     | The position of the control (one of the map corners). See [control positions](http://leafletjs.com/reference.html#control-positions). |
+| `position`           | `String`  | `'topright'`       | The position of the control (one of the map corners). See [control positions](http://leafletjs.com/reference.html#control-positions). |
 | `maxWidth`           | `Number`  | `100`              | Maximum width of the control in pixels. The width is set dynamically to show round values (e.g. 100, 200, 500). |
 | `updateWhenIdle`     | `Boolean` | `false`            | If true, the control is updated on moveend, otherwise it's always up-to-date (updated on move). |
 


### PR DESCRIPTION
Hi, just a quick fix for a wrong default value in the README.md that I've noticed while I was adding your scale to my [map for the Game Boy chip](http://iceboy.a-singer.de/dmg_cpu_b_map/). Works like a charm. Thank you!